### PR TITLE
GH-134: Compatibility with the latest SCSt

### DIFF
--- a/spring-cloud-starter-stream-processor-scriptable-transform/pom.xml
+++ b/spring-cloud-starter-stream-processor-scriptable-transform/pom.xml
@@ -26,10 +26,6 @@
 			<groupId>org.python</groupId>
 			<artifactId>jython-standalone</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud.stream.app</groupId>
-			<artifactId>app-starters-postprocessor-common</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-starter-stream-processor-scriptable-transform/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-stream-processor-scriptable-transform/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.env.EnvironmentPostProcessor=\
-  org.springframework.cloud.stream.app.postprocessor.ContentTypeEnvironmentPostProcessor

--- a/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.stream.app.scriptable.transform.processor;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
+
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,10 +32,6 @@ import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
 
 /**
  * Integration Tests for the Script Transform Processor.
@@ -52,7 +52,12 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 	@Autowired
 	protected MessageCollector collector;
 
-	@SpringBootTest({"scriptable-transformer.script=function add(a,b) { return a+b;};add(1,3)", "scriptable-transformer.language=js"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=function add(a,b) { return a+b;}; add(1,3)",
+					"scriptable-transformer.language=js",
+					"spring.cloud.stream.bindings.output.contentType=application/x-java-object"
+			})
 	public static class JavascriptScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -61,9 +66,15 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 			// Different Java versions return different types for JavaScript results
 			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(Matchers.<Number>isOneOf(4, 4L, 4.0)));
 		}
+
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=payload+foo", "scriptable-transformer.language=js", "scriptable-transformer.variables=foo=\\\\\40WORLD"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=payload+foo",
+					"scriptable-transformer.language=js",
+					"scriptable-transformer.variables=foo=\\\\\40WORLD"
+			})
 	public static class JavascriptScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -74,7 +85,13 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=payload*limit", "scriptable-transformer.language=js", "scriptable-transformer.variables=limit=5"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=payload*limit",
+					"scriptable-transformer.language=js",
+					"scriptable-transformer.variables=limit=5",
+					"spring.cloud.stream.bindings.output.contentType=application/x-java-object"
+			})
 	public static class JavascriptScriptProperty3Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -85,7 +102,12 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=payload+foo", "scriptable-transformer.language=groovy", "scriptable-transformer.variables=foo=\\\\\40WORLD"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=payload+foo",
+					"scriptable-transformer.language=groovy",
+					"scriptable-transformer.variables=foo=\\\\\40WORLD"
+			})
 	public static class GroovyScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -96,8 +118,12 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=payload.substring(0, limit as int) + foo", "scriptable-transformer.language=groovy",
-			"scriptable-transformer.variables=limit=5\\n foo=\\\\\40WORLD"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=payload.substring(0, limit as int) + foo",
+					"scriptable-transformer.language=groovy",
+					"scriptable-transformer.variables=limit=5\\n foo=\\\\\40WORLD"
+			})
 	public static class GroovyScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -108,7 +134,10 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=return \"\"#{payload.upcase}\"\"", "scriptable-transformer.language=ruby"})
+	@SpringBootTest(
+			{ "scriptable-transformer.script=return \"\"#{payload.upcase}\"\"",
+					"scriptable-transformer.language=ruby"
+			})
 	public static class RubyScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -119,7 +148,12 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=\"def foo(x)\\n  return x+5\\nend\\nfoo(payload)\\n\"", "scriptable-transformer.language=ruby"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=\"def foo(x)\\n  return x+5\\nend\\nfoo(payload)\\n\"",
+					"scriptable-transformer.language=ruby",
+					"spring.cloud.stream.bindings.output.contentType=application/x-java-object"
+			})
 	public static class RubyScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -132,8 +166,12 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	// Python not currently supported, problems running it in SCDF
 
-	@SpringBootTest({"scriptable-transformer.script=\"def multiply(x,y):\\n  return x*y\\nanswer = multiply(payload,5)\\n\"",
-			"scriptable-transformer.language=python"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=\"def multiply(x,y):\\n  return x*y\\nanswer = multiply(payload,5)\\n\"",
+					"scriptable-transformer.language=python",
+					"spring.cloud.stream.bindings.output.contentType=application/x-java-object"
+			})
 	public static class PythonScriptProperty1Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test
@@ -144,8 +182,11 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 
 	}
 
-	@SpringBootTest({"scriptable-transformer.script=\"def concat(x,y):\\n  return x+y\\nanswer = concat(\"\"hello \"\",payload)\\n\"",
-			"scriptable-transformer.language=python"})
+	@SpringBootTest(
+			{
+					"scriptable-transformer.script=\"def concat(x,y):\\n  return x+y\\nanswer = concat(\"\"hello \"\",payload)\\n\"",
+					"scriptable-transformer.language=python"
+			})
 	public static class PythonScriptProperty2Tests extends ScriptableTransformProcessorIntegrationTests {
 
 		@Test


### PR DESCRIPTION
Related to spring-cloud-stream-app-starters/app-starters-release#134

The Spring Cloud Stream doesn't do object conversion to the `byte[]`
if `contentType == application/octet-stream` any more.

* Add explicit `binding.output.contentType` into test-cases where we
expect Java objects instead of default JSON string representation
* Remove `ContentTypeEnvironmentPostProcessor` usage for explicit an
`application/octet-stream` `contentType` population in favor of default
to JSON
* Replace `@Transformer` for the `@ServiceActivator` since the former
doesn't honor `notPropagatedHeaders` and therefore an interceptor on
the `output` doesn't override copied `contentType` header from the request