### PR TITLE
Keep end-of-line of maven wrapper mvnw to LF (linefeed) 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mvnw text eol=lf


### PR DESCRIPTION
Even on windows, `mvnw` is a bash shell script that needs to be in unix format to be correctly executed.