### PR TITLE
use line.separator property in assert for plateform independent result

### DIFF
--- a/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-scriptable-transform/src/test/java/org/springframework/cloud/stream/app/scriptable/transform/processor/ScriptableTransformProcessorIntegrationTests.java
@@ -207,7 +207,8 @@ public abstract class ScriptableTransformProcessorIntegrationTests {
 		@Test
 		public void testRuby() {
 			channels.input().send(new GenericMessage<Object>("def age=18"));
-			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is("var age = 18;\n")));
+			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is("var age = 18;"
+					+ System.getProperty("line.separator"))));
 		}
 
 	}


### PR DESCRIPTION
This test fails on windows otherwise because the payload received has "\r\n".